### PR TITLE
Add fastbootd fallback confirmation for flashing

### DIFF
--- a/cli/src/handlers/flash.rs
+++ b/cli/src/handlers/flash.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressStyle};
 use lfff_lib::flasher::{
-    collect_images, collect_images_from_source, is_preloader, is_xbl_abl,
+    collect_images, collect_images_from_source, fastbootd_status, is_preloader, is_xbl_abl,
     run_flash_session_with_log, FirmwareSource, FlashOptions, FlashProgress,
+    FastbootdStatus,
 };
 
 use crate::output::{offer_wipe_and_reboot, print_check_report, print_summary, prompt, require_tools};
@@ -62,6 +63,31 @@ fn arb_gate(dir: &std::path::Path) -> bool {
     }
     let ans = prompt("\n  Type YES to confirm the ARB warning, anything else to abort", "");
     ans == "YES"
+}
+
+fn confirm_fastbootd_status(serial: Option<&str>) -> bool {
+    match fastbootd_status(serial) {
+        FastbootdStatus::Fastbootd => true,
+        FastbootdStatus::UserspaceFastboot => {
+            println!("\n{}", "── Fastbootd label warning ──────────────────────────────".dimmed());
+            println!("  {}", "Device reports userspace fastboot, but it is listed as plain 'fastboot'.".yellow());
+            println!("  {}", "This is a known OnePlus / OPPO / Realme issue: fastbootd may be usable even when the mode label does not say fastbootd.".dimmed());
+            println!("  {}", "Continuing will flash dynamic partitions from this userspace fastboot session.".dimmed());
+            let ans = prompt("\n  Continue anyway? (continue/stop)", "stop");
+            ans.eq_ignore_ascii_case("continue")
+        }
+        FastbootdStatus::BootloaderFastboot | FastbootdStatus::UnknownFastboot => {
+            println!("\n{}", "── Fastbootd warning ────────────────────────────────────".dimmed());
+            println!("  {}", "Device is not confirmed as fastbootd/userspace fastboot.".yellow());
+            println!("  {}", "Dynamic partition flashing may fail unless your device supports flashing them from this mode.".dimmed());
+            let ans = prompt("\n  Continue anyway? (continue/stop)", "stop");
+            ans.eq_ignore_ascii_case("continue")
+        }
+        FastbootdStatus::NotFound => {
+            eprintln!("{} {}", "✗".red().bold(), "No fastboot device found. Aborting.".red());
+            false
+        }
+    }
 }
 
 pub fn run(
@@ -169,6 +195,11 @@ pub fn run(
             return 1;
         }
 
+        if !confirm_fastbootd_status(serial) {
+            println!("{}", "Aborted by user (fastbootd check).".yellow());
+            return 1;
+        }
+
         // -- Snapdragon: ARB confirmation FIRST, final confirmation AFTER --
         if !as_mediatek && !source.is_source() && !arb_gate(dir) {
             println!("{}", "Aborted by user (ARB check).".yellow());
@@ -178,7 +209,7 @@ pub fn run(
         // -- Final confirmation --
         println!("\n{}", "── Final warning ────────────────────────────────────────".dimmed());
         println!("  {}", "All partitions will be overwritten. This action is irreversible.".red());
-        println!("  {}", "The device must be in fastbootd mode.".dimmed());
+        println!("  {}", "The device should be in fastbootd/userspace fastboot; any warning above must be accepted.".dimmed());
         let ans = prompt("\n  Type FLASH to start flashing, anything else to abort", "");
         if ans != "FLASH" {
             println!("{}", "Aborted by user.".yellow());

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -27,6 +27,7 @@ mod confirm_action {
     pub const FLASH_FAILURE: i32 = 10;
     pub const SESSION_ERROR: i32 = 11;
     pub const FLASH_METHOD: i32 = 12;
+    pub const FASTBOOTD_FALLBACK: i32 = 13;
 }
 
 /// Flash method — always an explicit user choice, never auto-detected.
@@ -52,6 +53,7 @@ enum WMsg {
     ReadyToFlash,
     CableTestProgress { step: u8, total: u8, status: String },
     FlashFailure { partition: String, slot: String, error: String, response: std::sync::mpsc::Sender<lfff_lib::flasher::FailureAction> },
+    FastbootdFallback { detail: String, response: std::sync::mpsc::Sender<bool> },
     UpdateAvailable { version: String, url: String, body: String },
 }
 
@@ -164,6 +166,7 @@ fn main() -> Result<(), slint::PlatformError> {
     let flash_cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let flash_cancel_w = flash_cancel.clone();
     let fail_resp = std::rc::Rc::new(std::cell::RefCell::new(None));
+    let fastbootd_resp = std::rc::Rc::new(std::cell::RefCell::new(None));
 
     thread::spawn(move || worker::worker(crx, mtx, flash_cancel_w));
 
@@ -173,7 +176,7 @@ fn main() -> Result<(), slint::PlatformError> {
 
     models.refresh_history();
 
-    ui_callbacks::register_callbacks(&ui, &ctx, &models, &fail_resp, &flash_cancel);
+    ui_callbacks::register_callbacks(&ui, &ctx, &models, &fail_resp, &fastbootd_resp, &flash_cancel);
 
     ctx.send(Cmd::CheckForUpdates).ok();
 
@@ -181,8 +184,9 @@ fn main() -> Result<(), slint::PlatformError> {
     let timer = slint::Timer::default();
     let mut last_dl_pct: u32 = 0;
     let fr_poll = fail_resp.clone();
+    let fb_poll = fastbootd_resp.clone();
     timer.start(slint::TimerMode::Repeated, Duration::from_millis(50), move || {
-        ui_callbacks::poll(&w, &mrx, &mut last_dl_pct, &models, &fr_poll);
+        ui_callbacks::poll(&w, &mrx, &mut last_dl_pct, &models, &fr_poll, &fb_poll);
     });
 
     ui.run()

--- a/gui/src/ui_callbacks.rs
+++ b/gui/src/ui_callbacks.rs
@@ -38,6 +38,7 @@ pub fn poll(
     last_dl_pct: &mut u32,
     models: &LogModels,
     fail_resp: &std::rc::Rc<std::cell::RefCell<Option<std::sync::mpsc::Sender<lfff_lib::flasher::FailureAction>>>>,
+    fastbootd_resp: &std::rc::Rc<std::cell::RefCell<Option<std::sync::mpsc::Sender<bool>>>>,
 ) {
     let Some(ui) = w.upgrade() else { return };
 
@@ -95,6 +96,12 @@ pub fn poll(
                 ui.set_confirm_action(confirm_action::FLASH_FAILURE);
                 ui.set_show_confirm(true);
                 *fail_resp.borrow_mut() = Some(response);
+            }
+            WMsg::FastbootdFallback { detail, response } => {
+                ui.set_fastbootd_fallback_detail(detail.into());
+                ui.set_confirm_action(confirm_action::FASTBOOTD_FALLBACK);
+                ui.set_show_confirm(true);
+                *fastbootd_resp.borrow_mut() = Some(response);
             }
             WMsg::DepsResult { message, ok } => add_log(models, &ui, if ok { &LogLevel::Success } else { &LogLevel::Error }, 0, &message),
             WMsg::Flashing(f) => ui.set_is_flashing(f),
@@ -167,6 +174,7 @@ pub fn register_callbacks(
     ctx: &mpsc::Sender<Cmd>,
     models: &LogModels,
     fail_resp: &std::rc::Rc<std::cell::RefCell<Option<std::sync::mpsc::Sender<lfff_lib::flasher::FailureAction>>>>,
+    fastbootd_resp: &std::rc::Rc<std::cell::RefCell<Option<std::sync::mpsc::Sender<bool>>>>,
     flash_cancel: &std::sync::Arc<std::sync::atomic::AtomicBool>,
 ) {
     let t = ctx.clone();
@@ -455,6 +463,16 @@ pub fn register_callbacks(
     let fr = fail_resp.clone();
     ui.on_flash_fail_retry(move || {
         if let Some(tx) = fr.borrow_mut().take() { tx.send(lfff_lib::flasher::FailureAction::Retry).ok(); }
+    });
+
+    let fb = fastbootd_resp.clone();
+    ui.on_fastbootd_fallback_continue(move || {
+        if let Some(tx) = fb.borrow_mut().take() { tx.send(true).ok(); }
+    });
+
+    let fb = fastbootd_resp.clone();
+    ui.on_fastbootd_fallback_stop(move || {
+        if let Some(tx) = fb.borrow_mut().take() { tx.send(false).ok(); }
     });
 
     let t = ctx.clone();

--- a/gui/src/worker.rs
+++ b/gui/src/worker.rs
@@ -128,6 +128,85 @@ fn wait_for_fastboot(tx: &mpsc::Sender<WMsg>, tab: u8, timeout_secs: u64, serial
     }
 }
 
+fn fastbootd_fallback_detail(status: lfff_lib::flasher::FastbootdStatus) -> String {
+    match status {
+        lfff_lib::flasher::FastbootdStatus::UserspaceFastboot => {
+            "The device is listed as plain 'fastboot', but it reports 'is-userspace: yes'. This is a known OnePlus / OPPO / Realme fastbootd label issue. Continuing will use this userspace fastboot session for dynamic partitions.".into()
+        }
+        lfff_lib::flasher::FastbootdStatus::BootloaderFastboot => {
+            "The device is still listed as bootloader fastboot and did not confirm userspace fastboot. Dynamic partition flashing may fail from this mode. Continue only if this device is known to support it.".into()
+        }
+        lfff_lib::flasher::FastbootdStatus::UnknownFastboot => {
+            "A fastboot device is connected, but LFFF could not confirm fastbootd/userspace mode. Dynamic partition flashing may fail from this mode.".into()
+        }
+        lfff_lib::flasher::FastbootdStatus::NotFound => {
+            "No fastboot device was found.".into()
+        }
+        lfff_lib::flasher::FastbootdStatus::Fastbootd => String::new(),
+    }
+}
+
+fn confirm_fastbootd_fallback(
+    tx: &mpsc::Sender<WMsg>,
+    tab: u8,
+    status: lfff_lib::flasher::FastbootdStatus,
+) -> bool {
+    let detail = fastbootd_fallback_detail(status);
+    log(tx, LogLevel::Warn, tab, detail.clone());
+    let (resp_tx, resp_rx) = std::sync::mpsc::channel();
+    if tx.send(WMsg::FastbootdFallback { detail, response: resp_tx }).is_err() {
+        return false;
+    }
+    resp_rx.recv().unwrap_or(false)
+}
+
+fn handle_fastbootd_status(
+    tx: &mpsc::Sender<WMsg>,
+    tab: u8,
+    status: lfff_lib::flasher::FastbootdStatus,
+) -> bool {
+    match status {
+        lfff_lib::flasher::FastbootdStatus::Fastbootd => {
+            log(tx, LogLevel::Success, tab, "Device confirmed in fastbootd");
+            true
+        }
+        lfff_lib::flasher::FastbootdStatus::UserspaceFastboot => {
+            if confirm_fastbootd_fallback(tx, tab, status) {
+                log(tx, LogLevel::Success, tab, "Continuing with confirmed userspace fastboot");
+                true
+            } else {
+                log(tx, LogLevel::Warn, tab, "Stopped by user at fastbootd warning");
+                false
+            }
+        }
+        lfff_lib::flasher::FastbootdStatus::BootloaderFastboot
+        | lfff_lib::flasher::FastbootdStatus::UnknownFastboot => {
+            if confirm_fastbootd_fallback(tx, tab, status) {
+                log(tx, LogLevel::Warn, tab, "Continuing without confirmed fastbootd/userspace mode");
+                true
+            } else {
+                log(tx, LogLevel::Warn, tab, "Stopped by user at fastbootd warning");
+                false
+            }
+        }
+        lfff_lib::flasher::FastbootdStatus::NotFound => {
+            log(tx, LogLevel::Error, tab, "Device not found in fastbootd");
+            false
+        }
+    }
+}
+
+fn wait_for_flash_fastbootd(
+    tx: &mpsc::Sender<WMsg>,
+    tab: u8,
+    serial: Option<&str>,
+    timeout_secs: u64,
+) -> bool {
+    log(tx, LogLevel::Info, tab, "Waiting for device to enter fastbootd/userspace fastboot...");
+    let status = lfff_lib::flasher::wait_for_fastbootd_status(serial, timeout_secs);
+    handle_fastbootd_status(tx, tab, status)
+}
+
 fn do_flash(
     tx: &mpsc::Sender<WMsg>,
     source: &lfff_lib::flasher::FirmwareSource,
@@ -360,8 +439,7 @@ pub fn worker(
                             if let Some(s) = &serial { ser_s = s.clone(); args.extend(["-s", ser_s.as_str()]); }
                             args.extend(["reboot", "fastboot"]);
                             let _ = std::process::Command::new("adb").args(&args).status();
-                            log(&tx, LogLevel::Info, 2, "Waiting for device to enter fastbootd...");
-                            lfff_lib::flasher::wait_for_fastbootd(serial.as_deref(), 90)
+                            wait_for_flash_fastbootd(&tx, 2, serial.as_deref(), 90)
                         }
                         2 => {
                             // No fixed sleep: the device is currently in
@@ -374,19 +452,12 @@ pub fn worker(
                             if let Some(s) = &serial { ser_s = s.clone(); args.extend(["-s", ser_s.as_str()]); }
                             args.extend(["reboot", "fastboot"]);
                             let _ = std::process::Command::new("fastboot").args(&args).status();
-                            log(&tx, LogLevel::Info, 2, "Waiting for device to enter fastbootd...");
-                            lfff_lib::flasher::wait_for_fastbootd(serial.as_deref(), 90)
+                            wait_for_flash_fastbootd(&tx, 2, serial.as_deref(), 90)
                         }
                         3 => {
-                            log(&tx, LogLevel::Info, 2, "Verifying device is in fastbootd mode...");
-                            let fb = lfff_lib::device::list_fastbootd_devices();
-                            if !fb.is_empty() {
-                                log(&tx, LogLevel::Success, 2, "Device confirmed in fastbootd");
-                                true
-                            } else {
-                                log(&tx, LogLevel::Error, 2, "Device is NOT in fastbootd mode — it may be in bootloader (fastboot) instead. Please reboot to fastbootd and try again.");
-                                false
-                            }
+                            log(&tx, LogLevel::Info, 2, "Verifying device is in fastbootd/userspace fastboot mode...");
+                            let status = lfff_lib::flasher::fastbootd_status(serial.as_deref());
+                            handle_fastbootd_status(&tx, 2, status)
                         }
                         _ => false,
                     };
@@ -394,11 +465,8 @@ pub fn worker(
                         adopt_fastboot_serial(&tx, &mut serial, 2);
                         tx.send(WMsg::ReadyToFlash).ok();
                     } else {
-                        log(&tx, LogLevel::Error, 2, "Device not found in fastbootd — aborting");
-                        tx.send(WMsg::FlashComplete {
-                            success: false, message: "Device not found in fastbootd".into(),
-                            log_summary: "Device not found".into(), failed_partitions: vec![],
-                        }).ok();
+                        log(&tx, LogLevel::Warn, 2, "Flash flow stopped before flashing");
+                        tx.send(WMsg::Flashing(false)).ok();
                     }
                 }
 
@@ -503,7 +571,7 @@ pub fn worker(
                     };
                     match lfff_lib::device::get_device_info(serial.as_deref()) {
                         None => {
-                            abort("Cannot communicate with the device (fastboot getvar failed). Check the cable and that the device is in fastbootd.");
+                            abort("Cannot communicate with the device (fastboot getvar failed). Check the cable and that the device is in fastbootd/userspace fastboot.");
                             continue;
                         }
                         Some(info) => {

--- a/gui/ui/globals/confirm-action.slint
+++ b/gui/ui/globals/confirm-action.slint
@@ -12,4 +12,5 @@ export global ConfirmAction {
     out property <int> flash-failure: 10;
     out property <int> session-error: 11;
     out property <int> flash-method: 12;
+    out property <int> fastbootd-fallback: 13;
 }

--- a/gui/ui/globals/tr.slint
+++ b/gui/ui/globals/tr.slint
@@ -78,12 +78,16 @@ export global Tr {
     out property <string> flash-reboot-from-system:     lang == "ru" ? "Из системы\n(adb reboot fastboot)" : "From system\n(adb reboot fastboot)";
     out property <string> flash-reboot-from-bootloader: lang == "ru" ? "Из Bootloader\n(fastboot reboot fastboot)" : "From bootloader\n(fastboot reboot fastboot)";
     out property <string> flash-reboot-skip:            lang == "ru" ? "Уже в Fastbootd\n(не перезагружаться)" : "Already in Fastbootd\n(don't reboot)";
+    out property <string> fastbootd-fallback-title: lang == "ru" ? "Fastbootd не подтверждён" : "Fastbootd not confirmed";
+    out property <string> fastbootd-fallback-warning: lang == "ru"
+        ? "Это известная особенность некоторых OnePlus / OPPO / Realme: userspace fastboot может отображаться как обычный fastboot. Продолжайте только если уверены."
+        : "This is a known issue on some OnePlus / OPPO / Realme devices: userspace fastboot can be listed as plain fastboot. Continue only if you trust this mode.";
 
     // Flash All step 2 — final confirm
     out property <string> flash-final-title: lang == "ru" ? "Последнее предупреждение" : "Final warning";
-    out property <string> flash-final-body:  lang == "ru" ? "Устройство находится в Fastbootd. Все разделы будут перезаписаны. Это действие необратимо.\n\nПродолжить прошивку?" : "Device is in Fastbootd. All partitions will be overwritten. This action is irreversible.\n\nProceed with flashing?";
+    out property <string> flash-final-body:  lang == "ru" ? "Устройство находится в Fastbootd или предупреждение о режиме fastboot было принято. Все разделы будут перезаписаны. Это действие необратимо.\n\nПродолжить прошивку?" : "Device is in Fastbootd, or the fastboot mode warning was accepted. All partitions will be overwritten. This action is irreversible.\n\nProceed with flashing?";
     out property <string> src-final-title:  lang == "ru" ? "Прошивка из исходников" : "Flash from source";
-    out property <string> src-final-body:   lang == "ru" ? "Устройство находится в Fastbootd. Образы из папки исходников будут прошиты. Это действие необратимо.\n\nПродолжить прошивку?" : "Device is in Fastbootd. Images from the source build folder will be flashed. This action is irreversible.\n\nProceed with flashing?";
+    out property <string> src-final-body:   lang == "ru" ? "Устройство находится в Fastbootd или предупреждение о режиме fastboot было принято. Образы из папки исходников будут прошиты. Это действие необратимо.\n\nПродолжить прошивку?" : "Device is in Fastbootd, or the fastboot mode warning was accepted. Images from the source build folder will be flashed. This action is irreversible.\n\nProceed with flashing?";
 
     // Flash Partition step 1 — reboot to bootloader
     out property <string> part-reboot-title:        lang == "ru" ? "Откуда перезагрузиться в Bootloader?" : "How to reboot into Bootloader?";

--- a/gui/ui/main.slint
+++ b/gui/ui/main.slint
@@ -28,6 +28,7 @@ import { FlashFailureDialog } from "dialogs/flash-failure-dialog.slint";
 import { ArbWarningDialog } from "dialogs/arb-warning-dialog.slint";
 import { PreloaderWarningDialog } from "dialogs/preloader-warning-dialog.slint";
 import { UpdateDialog } from "dialogs/update-dialog.slint";
+import { WarningDialog } from "dialogs/all.slint";
 
 export component MainWindow inherits Window {
     title: "LibreFastbootFirmwareFlasher";
@@ -153,6 +154,7 @@ export component MainWindow inherits Window {
     in-out property <string>  flash-fail-partition: "";
     in-out property <string>  flash-fail-slot: "";
     in-out property <string>  flash-fail-error: "";
+    in-out property <string>  fastbootd-fallback-detail: "";
 
     init => { Tr.lang = lang; Palette.color-scheme = is-dark ? ColorScheme.dark : ColorScheme.light; }
     changed lang => { Tr.lang = lang; }
@@ -184,6 +186,8 @@ export component MainWindow inherits Window {
     callback flash-fail-skip();
     callback flash-fail-abort();
     callback flash-fail-retry();
+    callback fastbootd-fallback-continue();
+    callback fastbootd-fallback-stop();
     callback export-flash-log();
     callback export-partition-log();
     callback export-device-log();
@@ -428,6 +432,26 @@ export component MainWindow inherits Window {
             root.show-confirm = false;
             root.prepare-flash();
         }
+    }
+
+    WarningDialog {
+        show: root.show-confirm && root.confirm-action == ConfirmAction.fastbootd-fallback;
+        title: Tr.fastbootd-fallback-title;
+        body: root.fastbootd-fallback-detail;
+        warning-text: Tr.fastbootd-fallback-warning;
+        has-checkbox: false;
+        checkbox-text: "";
+        checkbox-checked: false;
+        lang: root.lang;
+        cancelled => {
+            root.show-confirm = false;
+            root.fastbootd-fallback-stop();
+        }
+        confirmed => {
+            root.show-confirm = false;
+            root.fastbootd-fallback-continue();
+        }
+        checkbox-toggled => {}
     }
 
     FlashFailureDialog {

--- a/lib/src/flasher.rs
+++ b/lib/src/flasher.rs
@@ -170,6 +170,24 @@ pub enum DeviceMode {
     Unknown,
 }
 
+/// Whether the current fastboot connection is suitable for userspace-fastboot
+/// operations. Some OnePlus / OPPO / Realme devices report plain `fastboot`
+/// even though `getvar is-userspace` says `yes`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FastbootdStatus {
+    Fastbootd,
+    UserspaceFastboot,
+    BootloaderFastboot,
+    UnknownFastboot,
+    NotFound,
+}
+
+impl FastbootdStatus {
+    pub fn is_usable(self) -> bool {
+        matches!(self, Self::Fastbootd | Self::UserspaceFastboot)
+    }
+}
+
 /// Result of flashing a single partition.
 #[derive(Debug, Clone)]
 pub struct FlashResult {
@@ -324,6 +342,76 @@ fn fastboot_device_list() -> Vec<(String, String)> {
         .collect()
 }
 
+fn target_fastboot_device(serial: Option<&str>) -> Option<(String, String)> {
+    let devices = fastboot_device_list();
+    if devices.is_empty() {
+        return None;
+    }
+    if let Some(s) = serial {
+        if let Some(device) = devices.iter().find(|(ser, _)| ser == s) {
+            return Some(device.clone());
+        }
+        if devices.len() == 1 {
+            warn!(
+                "Expected serial {} but found single device {} — accepting (serial can change between adb and fastboot)",
+                s, devices[0].0
+            );
+            return Some(devices[0].clone());
+        }
+        return None;
+    }
+    devices.into_iter().next()
+}
+
+fn parse_fastboot_getvar(output: &str, key: &str) -> Option<String> {
+    for line in output.lines() {
+        let line = line.trim().trim_start_matches("(bootloader)").trim();
+        if let Some((k, v)) = line.split_once(':')
+            && k.trim() == key {
+                return Some(v.trim().to_string());
+            }
+    }
+    None
+}
+
+fn fastboot_getvar(serial: Option<&str>, key: &str, timeout: u64) -> Option<String> {
+    let mut args: Vec<&str> = Vec::new();
+    push_serial_arg(&mut args, serial);
+    args.extend(&["getvar", key]);
+
+    let (rc, out, err) = fastboot_cmd(&args, timeout);
+    if rc != 0 && out.is_empty() && err.is_empty() {
+        return None;
+    }
+    parse_fastboot_getvar(&format!("{}\n{}", out, err), key)
+}
+
+pub fn is_userspace_fastboot(serial: Option<&str>) -> Option<bool> {
+    let (ser, _) = target_fastboot_device(serial)?;
+    let value = fastboot_getvar(Some(&ser), "is-userspace", 10)?;
+    match value.to_lowercase().as_str() {
+        "yes" | "true" | "1" => Some(true),
+        "no" | "false" | "0" => Some(false),
+        _ => None,
+    }
+}
+
+pub fn fastbootd_status(serial: Option<&str>) -> FastbootdStatus {
+    let Some((ser, mode)) = target_fastboot_device(serial) else {
+        return FastbootdStatus::NotFound;
+    };
+    if mode == "fastbootd" {
+        return FastbootdStatus::Fastbootd;
+    }
+    if is_userspace_fastboot(Some(&ser)) == Some(true) {
+        return FastbootdStatus::UserspaceFastboot;
+    }
+    if mode == "fastboot" {
+        return FastbootdStatus::BootloaderFastboot;
+    }
+    FastbootdStatus::UnknownFastboot
+}
+
 /// True when a device in the target mode is present.
 ///
 /// When a serial is given but not found, a single device in the target mode is
@@ -379,7 +467,33 @@ fn wait_for_mode(
 
 /// Poll until device reports 'fastbootd' mode.
 pub fn wait_for_fastbootd(serial: Option<&str>, timeout: u64) -> bool {
-    wait_for_mode(serial, timeout, &|m| m == "fastbootd", "fastbootd")
+    wait_for_fastbootd_status(serial, timeout).is_usable()
+}
+
+/// Poll until the device is usable for fastbootd operations, accepting devices
+/// that report `is-userspace: yes` even when the mode label remains `fastboot`.
+pub fn wait_for_fastbootd_status(serial: Option<&str>, timeout: u64) -> FastbootdStatus {
+    let deadline = Instant::now() + std::time::Duration::from_secs(timeout);
+    let mut last_log = Instant::now();
+    let mut last_status = FastbootdStatus::NotFound;
+    loop {
+        let status = fastbootd_status(serial);
+        if status.is_usable() {
+            return status;
+        }
+        if status != FastbootdStatus::NotFound {
+            last_status = status;
+        }
+        if Instant::now() >= deadline {
+            return last_status;
+        }
+        if last_log.elapsed().as_secs() >= 5 {
+            let remaining = (deadline - Instant::now()).as_secs();
+            info!("Waiting for fastbootd/userspace fastboot ... ({}s left)", remaining);
+            last_log = Instant::now();
+        }
+        thread::sleep(std::time::Duration::from_millis(POLL_INTERVAL_MS));
+    }
 }
 
 /// Poll until device reports 'fastboot' (bootloader) mode.
@@ -1067,6 +1181,18 @@ pub fn run_flash_session_with_log(
 
     // -- Stage 1: fastbootd (all partitions on MediaTek, non-bootloader on Snapdragon) --
     if !fastbootd_images.is_empty() {
+        match fastbootd_status(serial) {
+            FastbootdStatus::Fastbootd => {}
+            FastbootdStatus::UserspaceFastboot => {
+                on_log("Warning: device reports userspace fastboot but is listed as 'fastboot'. This is a known OnePlus/OPPO/Realme fastbootd label issue; continuing after user confirmation.".into());
+            }
+            FastbootdStatus::BootloaderFastboot | FastbootdStatus::UnknownFastboot => {
+                on_log("Warning: device is not confirmed as fastbootd/userspace fastboot. Dynamic partition flashing may fail.".into());
+            }
+            FastbootdStatus::NotFound => {
+                on_log("Warning: no fastboot device found while starting fastbootd stage.".into());
+            }
+        }
         let active_slot = match get_active_slot(serial) {
             Some(s) => s,
             None => {


### PR DESCRIPTION
This pull request introduces improved detection and user confirmation for fastbootd and userspace fastboot modes in both the CLI and GUI flashing workflows. It adds explicit warnings and confirmation dialogs when the device is not clearly in fastbootd mode, addressing known issues with some devices (notably OnePlus/OPPO/Realme) where userspace fastboot is mislabeled. The changes enhance user safety and awareness before flashing dynamic partitions, and provide localized warning messages and improved UI handling.

**Fastbootd detection and user confirmation improvements:**

* Added logic in the CLI (`cli/src/handlers/flash.rs`) to detect fastbootd/userspace fastboot/bootloader fastboot/unknown fastboot status before flashing, present clear warnings, and require explicit user confirmation to continue if the status is not ideal. [[1]](diffhunk://#diff-d3e89caea6e9761e67b56615444fd1f67732fc33c035c2f0759b0814bec9cbc2L7-R9) [[2]](diffhunk://#diff-d3e89caea6e9761e67b56615444fd1f67732fc33c035c2f0759b0814bec9cbc2R68-R92) [[3]](diffhunk://#diff-d3e89caea6e9761e67b56615444fd1f67732fc33c035c2f0759b0814bec9cbc2R198-R202) [[4]](diffhunk://#diff-d3e89caea6e9761e67b56615444fd1f67732fc33c035c2f0759b0814bec9cbc2L181-R212)
* In the GUI, implemented a new confirmation dialog for fastbootd fallback scenarios, including detailed warnings and user response handling. Added new message types, callbacks, and UI properties to support this flow. [[1]](diffhunk://#diff-0922134edd56314700243a78013f374258b1639e312d60a58b43cc5fe9ca2062R30) [[2]](diffhunk://#diff-0922134edd56314700243a78013f374258b1639e312d60a58b43cc5fe9ca2062R56) [[3]](diffhunk://#diff-0922134edd56314700243a78013f374258b1639e312d60a58b43cc5fe9ca2062R169) [[4]](diffhunk://#diff-0922134edd56314700243a78013f374258b1639e312d60a58b43cc5fe9ca2062L176-R189) [[5]](diffhunk://#diff-b628b819f2490dd9d05ea2e2efdc982f1520f29c24a4f31f47725dde1516f731R41) [[6]](diffhunk://#diff-b628b819f2490dd9d05ea2e2efdc982f1520f29c24a4f31f47725dde1516f731R100-R105) [[7]](diffhunk://#diff-b628b819f2490dd9d05ea2e2efdc982f1520f29c24a4f31f47725dde1516f731R177) [[8]](diffhunk://#diff-b628b819f2490dd9d05ea2e2efdc982f1520f29c24a4f31f47725dde1516f731R468-R477) [[9]](diffhunk://#diff-10ebb8cf61979c6ddf07a7883a94a55a1ae6b6e696319fe34e0a454d04f000fdR31) [[10]](diffhunk://#diff-10ebb8cf61979c6ddf07a7883a94a55a1ae6b6e696319fe34e0a454d04f000fdR157) [[11]](diffhunk://#diff-10ebb8cf61979c6ddf07a7883a94a55a1ae6b6e696319fe34e0a454d04f000fdR189-R190)

**Worker and backend logic updates:**

* Refactored the GUI worker logic to use the new fastbootd status detection and confirmation flow, replacing the previous simple checks with detailed status handling and user interaction. [[1]](diffhunk://#diff-2230ad0460d9777a1f0d76fc4f8e05c373d5bae245668c4182a0800576d47bdfR131-R209) [[2]](diffhunk://#diff-2230ad0460d9777a1f0d76fc4f8e05c373d5bae245668c4182a0800576d47bdfL363-R442) [[3]](diffhunk://#diff-2230ad0460d9777a1f0d76fc4f8e05c373d5bae245668c4182a0800576d47bdfL377-R469) [[4]](diffhunk://#diff-2230ad0460d9777a1f0d76fc4f8e05c373d5bae245668c4182a0800576d47bdfL506-R574)

**Localization and UI messaging:**

* Added new localized strings for fastbootd fallback warnings and updated final confirmation messages to reflect the improved detection and warning acceptance, in both English and Russian. [[1]](diffhunk://#diff-b3924088b0bf5ca29217f958ae0d06044aaee5fb3f27e0d1c88b15326acd7c39R81-R90) [[2]](diffhunk://#diff-6e301e1ebd91230a3e12e3c3e4d219fbfb8033ee11ac7eb724cc7b444767aeabR15)

These changes significantly improve user safety and clarity when flashing devices that may not be in the expected fastbootd mode, especially for devices with known fastboot labeling issues.

Tested on OnePlus11